### PR TITLE
setting absolute path instead of realative for symlinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,12 @@ if (BUILD_PYTHON_WRAPPER)
         target_link_libraries( iiboost_python ${COMMON_LIBS} python2.7 rt)
     endif()
 
-    _create_symlink(iiboost_python "testData/img.jlb" "img.jlb")
-    _create_symlink(iiboost_python "testData/gt.jlb" "gt.jlb")
-    _create_symlink(iiboost_python "python/python_test_raw.py"   "python_test_raw.py")
-    _create_symlink(iiboost_python "python/python_test_class.py" "python_test_class.py")
-    _create_symlink(iiboost_python "python/IIBoost.py" "IIBoost.py")
+    _create_symlink(iiboost_python "${CMAKE_SOURCE_DIR}/testData/img.jlb" "img.jlb")
+    _create_symlink(iiboost_python "${CMAKE_SOURCE_DIR}/testData/gt.jlb" "gt.jlb")
+    _create_symlink(iiboost_python "${CMAKE_SOURCE_DIR}/python/python_test_raw.py"   "python_test_raw.py")
+    _create_symlink(iiboost_python "${CMAKE_SOURCE_DIR}/python/python_computeII_example.py" "python_computeII_example.py")
+    _create_symlink(iiboost_python "${CMAKE_SOURCE_DIR}/python/python_test_class.py" "python_test_class.py")
+    _create_symlink(iiboost_python "${CMAKE_SOURCE_DIR}/python/IIBoost.py" "IIBoost.py")
 
 endif()
 


### PR DESCRIPTION
Relative path is invalid when ran from the build directory, changed to complete paths
