### PR TITLE
Adding Z anisotropy Factor requirement

### DIFF
--- a/globaldefs.h
+++ b/globaldefs.h
@@ -28,8 +28,8 @@ typedef double AdaBoostErrorType;
 
 // Ground Truth
 typedef unsigned char	GTPixelType;
-static const GTPixelType GTNegLabel = 0;
-static const GTPixelType GTPosLabel = 2;
+static const GTPixelType GTNegLabel = 128;
+static const GTPixelType GTPosLabel = 255;
 
 // supervoxel or voxel-based?
 // So far, no supervoxel support available

--- a/python/IIBoost.py
+++ b/python/IIBoost.py
@@ -87,7 +87,7 @@ class Booster:
 		self.modelPtr = newModelPtr
 
 
-	def trainWithChannels( self, imgStackList, gtStackList, chStackListList, numStumps, debugOutput = False ):
+	def trainWithChannels( self, imgStackList, gtStackList, chStackListList, zAnisotropyFactor, numStumps, debugOutput = False ):
 			""" Train a boosted classifier """
 			"""   imgStackList: list of images, of type uint8 """
 			"""   gtStackList:  list of GT, of type uint8. Negative = 1, Positive = 2, Ignore = else      """
@@ -146,7 +146,7 @@ class Booster:
 											width, height, depth,
 											ctypes.c_int( len(imgs) ),
 											chans,
-											ctypes.c_int( numChannels ),
+											ctypes.c_int( numChannels ), ctypes.c_double(zAnisotropyFactor),
 											ctypes.c_int(numStumps), dbgOut ) )
 
 			if newModelPtr.value == None:
@@ -156,7 +156,7 @@ class Booster:
 			self.modelPtr = newModelPtr
 
 
-	def predictWithChannels( self, imgStack, chStackList ):
+	def predictWithChannels( self, imgStack, chStackList, zAnisotropyFactor):
 		""" Per-pixel prediction for single ROI/image 	"""
 		"""   imgStack: 	image itself 					 """
 		"""   chStackList:  list of integral images/channels """
@@ -195,7 +195,7 @@ class Booster:
 				ctypes.c_void_p(imgStack.ctypes.data),
 				ctypes.c_int(width), ctypes.c_int(height), ctypes.c_int(depth),
 				chans,
-				ctypes.c_int( len(chans) ),
+				ctypes.c_int( len(chans) ), ctypes.c_double(zAnisotropyFactor),
 				ctypes.c_void_p(pred.ctypes.data) )
 
 		ret = ctypes.c_int(ret)

--- a/python/iiboost_python.cpp
+++ b/python/iiboost_python.cpp
@@ -61,7 +61,7 @@ extern "C"
     int predictWithChannels( void *modelPtr, ImagePixelType *imgPtr,
                               int width, int height, int depth,
                               IntegralImagePixelType **chImgPtr,
-                              int numChannels,
+                              int numChannels, double zAnisotropyFactor,
                               PredictionPixelType *predPtr )
     {
         Matrix3D<PredictionPixelType> predMatrix;
@@ -69,7 +69,7 @@ extern "C"
 
         // create roi for image, no GT available
         ROIData roi;
-        roi.init( imgPtr, 0, 0, 0, width, height, depth );
+        roi.init( imgPtr, 0, 0, 0, width, height, depth, zAnisotropyFactor);
 
         ROIData::IntegralImageType ii[numChannels];  // TODO: remove
 
@@ -107,7 +107,7 @@ extern "C"
                              int *width, int *height, int *depth,
                              int numStacks,
                              IntegralImagePixelType **chImgPtr,
-                             int numChannels,
+                             int numChannels, double zAnisotropyFactor,
                              int numStumps, int debugOutput )
     {
 
@@ -121,7 +121,7 @@ extern "C"
 
             for (int i=0; i < numStacks; i++)
             {
-                rois[i].init( imgPtr[i], gtPtr[i], 0, 0, width[i], height[i], depth[i] );
+                rois[i].init( imgPtr[i], gtPtr[i], 0, 0, width[i], height[i], depth[i], zAnisotropyFactor);
 
                 for (int ch=0; ch < numChannels; ch++)
                 {

--- a/python/python_channels_test_class.py
+++ b/python/python_channels_test_class.py
@@ -30,11 +30,10 @@ channel1 = iiImage
 channel2 = iiImage
 channels3 = channels2 = channels1 = [channel1,channel2]
 
-
 # Train: note that we pass a list of stacks
-model.trainWithChannels( [img1,img2,img3], [gt1,gt2,gt3], [channels1,channels2,channels3], numStumps=100, debugOutput=True)
+model.trainWithChannels( [img1,img2,img3], [gt1,gt2,gt3], [channels1,channels2,channels3], zAnisotropyFactor=5.0, numStumps=100, debugOutput=True)
 
-pred = model.predictWithChannels( img, channels1 )
+pred = model.predictWithChannels( img, channels1, zAnisotropyFactor )
 
 # show image & prediction side by side
 plt.ion()


### PR DESCRIPTION
In order for the ccboost algorithm to work properly we need to provide the Anisotropy of the volume. Now it is mandatory (note that this changes the API and therefore the examples won't work)

I've only tested with python_channels_test_class.py, setting momentarly globaldefs labels to 1 and 2.