### PR TITLE
Predictions of weak learners

### DIFF
--- a/Booster.h
+++ b/Booster.h
@@ -357,6 +357,39 @@ public:
 
 		mModel.setNumChannels( bid.imgData->ROIs[0]->integralImages.size() );
 	}
+	
+	void wlpredict(MultipleROIData& rois,
+				   Matrix3D<char> preds[],
+				   unsigned roiNo = 0,
+				   unsigned numThreads = IIBOOST_NUM_THREADS) const
+	{
+		MultipleROIData singleRoiData;
+		singleRoiData.add( rois.ROIs[roiNo] );
+
+		BoosterInputData bd;
+		bd.init( shared_ptr_nodelete(MultipleROIData, &singleRoiData), true);
+
+		// make sure we are given right number of channels
+		if (mModel.numChannels() != bd.imgData->ROIs[0]->integralImages.size() )
+			throw std::runtime_error("Number of channels for prediction not the same as for training.");
+
+		const unsigned N = mModel.size();
+		for (unsigned i=0; i < N; i++)
+		{
+			typedef Eigen::Array<char, Eigen::Dynamic, 1> ArrayXi8;
+			typedef Eigen::Map<ArrayXi8, Eigen::Unaligned> 	MapType;
+			typedef BoosterPredictOperatorNoAtomic<MapType>  OpType;
+			
+			Matrix3D<char> *pred = &preds[i];
+			pred->reallocSizeLike( singleRoiData.ROIs[0]->rawImage );
+			pred->fill(0);
+
+			MapType predMap(pred->data(), pred->numElem());
+			OpType op(predMap, 1);
+
+			mModel[i].wl.classifySingleROIWithOp<OpType, false>(mPoses, bd, op, numThreads);
+		}
+	}
 
 	// predicts roiNo in rois
 	template<bool TUseEarlyStopping = false>

--- a/Booster.h
+++ b/Booster.h
@@ -619,7 +619,7 @@ public:
             predMap.coeffRef(i) = std::max( predInvMap.coeff(i), predMap.coeff(i) );
     }
     
-    void wlpredict(MultipleROIData& rois,
+    void predictIndividualWeakLearners(MultipleROIData& rois,
                    Matrix3D<char> preds[],
                    unsigned roiNo = 0,
                    unsigned numThreads = IIBOOST_NUM_THREADS) const

--- a/python/iiboost/booster.py
+++ b/python/iiboost/booster.py
@@ -159,7 +159,7 @@ class Booster(object):
 		self.libPtr.train.restype = ctypes.c_void_p
 		self.libPtr.trainWithChannel.restype = ctypes.c_void_p
 		self.libPtr.trainWithChannels.restype = ctypes.c_void_p
-		self.libPtr.wlpredictWithChannels.restype = ctypes.c_int
+		self.libPtr.predictIndividualWeakLearnersWithChannels.restype = ctypes.c_int
 		self.libPtr.wlAlphas.restype = ctypes.py_object
 
 	# returns a string representation of the model
@@ -189,13 +189,13 @@ class Booster(object):
 		self.__init__()
 		self.deserialize(state)
 	
-	def number_of_weaklearners(self):
+	def numberOfWeakLearners(self):
 		if self.modelPtr is None:
 			raise ValueError("No model available") 
 		
 		return self.libPtr.numberOfWeakLearners(self.modelPtr)
 	
-	def wl_alphas(self):
+	def wlAlphas(self):
 		if self.modelPtr is None:
 			raise ValueError("No model available") 
 		
@@ -334,7 +334,7 @@ class Booster(object):
 
 		return pred
 
-	def wlpredictWithChannels(self, imgStack, eigVecImg, chStackList, zAnisotropyFactor):
+	def predictIndividualWeakLearnersWithChannels(self, imgStack, eigVecImg, chStackList, zAnisotropyFactor):
 		"""
 		Per-pixel predictions for every weak learner.
 		
@@ -352,13 +352,13 @@ class Booster(object):
 		height = imgStack.shape[1]
 		depth  = imgStack.shape[0]
 		
-		num_wl = self.number_of_weaklearners()
+		num_wl = self.numberOfWeakLearners()
 		
 		# pre-alloc prediction
 		pred = np.empty((num_wl,) + imgStack.shape, dtype=np.int8)
 		pred_c = as_carray([i.ctypes.data for i in pred], ctypes.c_void_p)
 		
-		ret = self.libPtr.wlpredictWithChannels(self.modelPtr,
+		ret = self.libPtr.predictIndividualWeakLearnersWithChannels(self.modelPtr,
 				ctypes.c_void_p(imgStack.ctypes.data),
 				ctypes.c_void_p(eigVecImg.ctypes.data),
 				ctypes.c_int(width), ctypes.c_int(height), ctypes.c_int(depth),

--- a/python/src/iiboost_python.cpp
+++ b/python/src/iiboost_python.cpp
@@ -60,8 +60,8 @@ extern "C"
             return 0;
         }
 
-		return model;
-	}
+        return model;
+    }
     
     DLL_EXPORT
     PyObject* wlAlphas(void *modelPtr)

--- a/python/src/iiboost_python.cpp
+++ b/python/src/iiboost_python.cpp
@@ -19,6 +19,7 @@
 #include "SmartPtrs.h"
 
 typedef float PredictionPixelType;
+typedef char WLPredictionPixelType;
 
 extern "C"
 {
@@ -52,14 +53,33 @@ extern "C"
 
 		return model;
 	}
-
+    
+    PyObject* wlAlphas(void *modelPtr)
+    {
+        BoosterModel* model = static_cast<BoosterModel*>(modelPtr);
+        
+        int num_wl = model->size();
+        PyObject* result = PyList_New(num_wl);
+        
+        for(int i=0; i < num_wl; ++i)
+        {
+            PyList_SetItem(result, i, PyFloat_FromDouble((*model)[i].alpha));
+        }
+        
+        return result;
+    }
+    
+    int numberOfWeakLearners(void *modelPtr)
+    {
+        return static_cast<BoosterModel*>(modelPtr)->size();
+    }
 
     // Prediction for a single ROI
     //  Accepts an arbitrary number of integral images/channels.
     //  Assumes that predPtr is already allocated, of same size as imgPtr
     //  Returns 0 if ok
     int predictWithChannels( void *modelPtr, ImagePixelType *imgPtr,
-    						  void *eigVecImgPtr,
+                              void *eigVecImgPtr,
                               int width, int height, int depth,
                               IntegralImagePixelType **chImgPtr,
                               int numChannels, double zAnisotropyFactor,
@@ -92,6 +112,50 @@ extern "C"
                 adaboost.predictWithFeatureOrdering<true>( allROIs, &predMatrix );
             else
                 adaboost.predictWithFeatureOrdering<false>( allROIs, &predMatrix );
+        }
+        catch( std::exception &e )
+        {
+            printf("Error in prediction: %s\n", e.what());
+            return -1;
+        }
+
+        return 0;
+    }
+
+    int wlpredictWithChannels( void *modelPtr, ImagePixelType *imgPtr,
+                               void *eigVecImgPtr,
+                               int width, int height, int depth,
+                               IntegralImagePixelType **chImgPtr,
+                               int numChannels, double zAnisotropyFactor,
+                               WLPredictionPixelType **predPtr)
+    {
+        BoosterModel* model = static_cast<BoosterModel*>(modelPtr);
+        
+        int numWL = model->size();
+        Matrix3D<WLPredictionPixelType> predMatrix[numWL]; // TODO: remove
+        for(int i=0; i < numWL; ++i)
+            predMatrix[i].fromSharedData(predPtr[i], width, height, depth);
+        
+        // create roi for image, no GT available
+        ROIData roi;
+        roi.init( imgPtr, 0, 0, 0, width, height, depth, zAnisotropyFactor, 0.0, (const ROIData::RotationMatrixType *) eigVecImgPtr );
+        ROIData::IntegralImageType ii[numChannels];  // TODO: remove
+
+        for (int ch=0; ch < numChannels; ch++)
+        {
+           ii[ch].fromSharedData(chImgPtr[ch], width, height, depth);
+
+           roi.addII( ii[ch].internalImage().data() );
+        }
+
+        MultipleROIData allROIs;
+        allROIs.add( shared_ptr_nodelete(ROIData, &roi) );
+
+        try
+        {
+            Booster adaboost;
+            adaboost.setModel(*model);
+            adaboost.wlpredict(allROIs, predMatrix);
         }
         catch( std::exception &e )
         {

--- a/python/src/iiboost_python.cpp
+++ b/python/src/iiboost_python.cpp
@@ -19,6 +19,8 @@
 #include "SmartPtrs.h"
 
 typedef float PredictionPixelType;
+
+// Pixel type for prediction of weak learners
 typedef char WLPredictionPixelType;
 
 #if defined(_MSC_VER)
@@ -134,12 +136,12 @@ extern "C"
     }
 
     DLL_EXPORT
-    int wlpredictWithChannels( void *modelPtr, ImagePixelType *imgPtr,
-                               void *eigVecImgPtr,
-                               int width, int height, int depth,
-                               IntegralImagePixelType **chImgPtr,
-                               int numChannels, double zAnisotropyFactor,
-                               WLPredictionPixelType **predPtr)
+    int predictIndividualWeakLearnersWithChannels( void *modelPtr, ImagePixelType *imgPtr,
+                                                   void *eigVecImgPtr,
+                                                   int width, int height, int depth,
+                                                   IntegralImagePixelType **chImgPtr,
+                                                   int numChannels, double zAnisotropyFactor,
+                                                   WLPredictionPixelType **predPtr)
     {
         BoosterModel* model = static_cast<BoosterModel*>(modelPtr);
         
@@ -167,7 +169,7 @@ extern "C"
         {
             Booster adaboost;
             adaboost.setModel(*model);
-            adaboost.wlpredict(allROIs, predMatrix);
+            adaboost.predictIndividualWeakLearners(allROIs, predMatrix);
         }
         catch( std::exception &e )
         {


### PR DESCRIPTION
New method `wlpredictWithChannels` for getting the predictions of every weak learner. The method `wl_alphas` returns the weights of the weak learners. Therefore, the final boosting scores could be obtained with

```python
wlpred = model.wlpredictWithChannels(image, eig, channels, anisotropy)
alphas = model.wl_alphas()
pred = np.tensordot(wlpred, alphas, (0,0)) 
```

`pred` should be equal (up to numerical precision) to the output of `predictWithChannels`:

```python
pred2 = model.predictWithChannels(image, eig, channels, anisotropy)
print np.allclose(pred, pred2) # Should be True
```
