### PR TITLE
Fix isnan() calls

### DIFF
--- a/ContextFeatures/ContextFeatures.h
+++ b/ContextFeatures/ContextFeatures.h
@@ -260,9 +260,9 @@ struct HistogramMeanThresholdData
             newPt.z = round(pt.z + invZAnisotropyFactor * orient.coeff(2));
 
             //FIXME: shouldn't have to check for NaN
-           if (isnan(newPt.x)) newPt.x = 1;
-           if (isnan(newPt.y)) newPt.y = 1;
-           if (isnan(newPt.z)) newPt.z = 1;
+           if (std::isnan(newPt.x)) newPt.x = 1;
+           if (std::isnan(newPt.y)) newPt.y = 1;
+           if (std::isnan(newPt.z)) newPt.z = 1;
 
             if (newPt.x < 1)    newPt.x = 1;
             if (newPt.y < 1)    newPt.y = 1;

--- a/HistogramMeanThreshold.h
+++ b/HistogramMeanThreshold.h
@@ -276,9 +276,9 @@ struct HistogramMeanThresholdData
             newPt.z = round(pt.z + invZAnisotropyFactor * orient.coeff(2));
 
             //FIXME //TODO quick bug patch
-           if (isnan(newPt.x)) newPt.x = 1;
-           if (isnan(newPt.y)) newPt.y = 1;
-           if (isnan(newPt.z)) newPt.z = 1;
+           if (std::isnan(newPt.x)) newPt.x = 1;
+           if (std::isnan(newPt.y)) newPt.y = 1;
+           if (std::isnan(newPt.z)) newPt.z = 1;
 
             if (newPt.x < 1)    newPt.x = 1;
             if (newPt.y < 1)    newPt.y = 1;

--- a/IntegralImage.h
+++ b/IntegralImage.h
@@ -73,7 +73,7 @@ public:
     template<typename S>
     static inline S removeNaN( S val )
     {
-    if ( isnan(val) || isinf(val) )
+    if ( std::isnan(val) || std::isinf(val) )
         return (S)0;
     else
         return val;

--- a/ROIData.h
+++ b/ROIData.h
@@ -145,7 +145,7 @@ public:
         for (long int i=0; i < numElem; i++)
         {
             auto total = _rotMatrices[i].sum();
-            if ( isnan(total) || isinf(total) )
+            if ( std::isnan(total) || std::isinf(total) )
                 _rotMatrices[i].setIdentity();
         }
     }


### PR DESCRIPTION
Apparently, on Mac, `isnan()` and `isinf()` aren't visible in the global namespace -- you have to get them from the `std` namespace, and you have to compile with `-std=c++11`.

But meanwhile on Linux (CenOS 5, at least), they *are* in the global namespace, so typing `using std::isnan` doesn't work (`error: ‘isnan’ is already declared in this scope`).

The only portable way (as far as I can see) is to use `std::isnan` everywhere (no `using` shortcut).

BTW: If I understand correctly, using `isnan()` is only portable when using c++11, so `iiboost` is now officially a c++11 code base, if it wasn't already.  (That's fine by me.)  For now, I just added `-DCMAKE_CXX_FLAGS="-std=c++11"` to my build script.  But you might want to consider adding it directly to `CMakeLists.txt`.