### PR TITLE
Small fixes for MSVC support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,21 +23,24 @@ else()
 endif()
 set(RANDOMLIB_INCPATH "${RANDOMLIB_DESTPATH}/include")
 
-
-externalproject_add( 
-    randomlibBuild
-    GIT_REPOSITORY http://git.code.sf.net/p/randomlib/code
-    GIT_TAG "r1.6"
-    CMAKE_ARGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+set(RANDOMLIB_CMAKE_ARGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                "-DCMAKE_INSTALL_PREFIX=${RANDOMLIB_DESTPATH}"
                "-DCMAKE_BUILD_TYPE=RELEASE"
                "-DMAINTAINER=OFF"
                "-DRANDOM_SHARED_LIB=OFF"
-               "-DCMAKE_C_FLAGS=-fpic"
-               "-DCMAKE_CXX_FLAGS=-fpic"
                "-DDISABLE_BOOST=ON"
-               "-DRANDOMLIB_DOCUMENTATION=OFF"
+               "-DRANDOMLIB_DOCUMENTATION=OFF")
+
+if(NOT MSVC)
+    set(RANDOMLIB_CMAKE_ARGS ${RANDOMLIB_CMAKE_ARGS} "-DCMAKE_C_FLAGS=-fpic" "-DCMAKE_CXX_FLAGS=-fpic")
+endif()
+
+externalproject_add( 
+    randomlibBuild
+    GIT_REPOSITORY http://git.code.sf.net/p/randomlib/code
+    GIT_TAG "r1.6"
+    CMAKE_ARGS ${RANDOMLIB_CMAKE_ARGS}
     UPDATE_COMMAND "" )
 
 add_library(randomlib STATIC IMPORTED DEPENDS)
@@ -75,7 +78,7 @@ add_definitions(-DVCL_CAN_STATIC_CONST_INIT_FLOAT=0 -DVCL_CAN_STATIC_CONST_INIT_
 if(MSVC)
     # NOTE: The slic library uses a preprocessor flag "WINDOWS". Do NOT set
     #       this flag for Visual Studio because it breaks everything
-    ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_DEPRECATE)
+    ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_DEPRECATE -DNOMINMAX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_FLAG}")
 else()
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++11 -O3 ${OPENMP_FLAG}")

--- a/IntegralImage.h
+++ b/IntegralImage.h
@@ -20,6 +20,7 @@
 #define INTEGRALIMAGE_H
 
 #include <Matrix3D.h>
+#include <cmath>
 #include <vector>
 
 // a box of center (x,y,z), radius (rx,ry,rz)
@@ -73,7 +74,7 @@ public:
     template<typename S>
     static inline S removeNaN( S val )
     {
-    if ( std::isnan(val) || std::isinf(val) )
+    if ( std::isnan((double)val) || std::isinf((double)val) )
         return (S)0;
     else
         return val;

--- a/ROIData.h
+++ b/ROIData.h
@@ -19,6 +19,7 @@
 #ifndef _ROI_DATA_H_
 #define _ROI_DATA_H_
 
+#include <cmath>
 #include <Eigen/Dense>
 #include <vector>
 

--- a/auxItk/AllEigenVectorsOfHessian.h
+++ b/auxItk/AllEigenVectorsOfHessian.h
@@ -99,7 +99,7 @@ namespace AllEigenVectorsOfHessian
 
     using namespace std;
 
-#if defined(_MSC_VER) && _MSC_VER <= 1700
+#if defined(_MSC_VER)
     #define showMsg(args) \
         do { \
             printf("\x1b[32m" "\x1b[1m["); \

--- a/slic/LKM.h
+++ b/slic/LKM.h
@@ -5,6 +5,8 @@
 // Email: firstname.lastname@epfl.ch
 //////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
+
 #if !defined(_LKM_H_INCLUDED_)
 #define _LKM_H_INCLUDED_
 


### PR DESCRIPTION
While packaging iiboost 0.2 for conda, I ran into some issues while building on Windows with MSVC. Some of these issues have been solved already in master, for the remaining ones I had to apply the changes in this PR. It is mostly about avoiding GCC-specific flags and minor header/macros fixes.